### PR TITLE
Add drv90 to enable pcf

### DIFF
--- a/sonoff/xdrv_interface.ino
+++ b/sonoff/xdrv_interface.ino
@@ -151,6 +151,10 @@ bool (* const xdrv_func_ptr[])(uint8_t) = {   // Driver Function Pointers
   &Xdrv32,
 #endif
 
+#ifdef XDRV_90
+  &Xdrv90,
+#endif
+
 // Optional user defined drivers in range 91 - 99
 
 #ifdef XDRV_91


### PR DESCRIPTION
PCF became "excluded" when it was changed from drv20 to drv90...

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
